### PR TITLE
(chore): Fixed nodejs version and add bower registry

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,3 +1,4 @@
 {
-    "directory" : "web/vendor/"
+    "directory" : "web/vendor/",
+    "registry": "https://registry.bower.io"
 }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
   },
   "author": "",
   "license": "ISC",
+  "engines": {
+    "node": "6.2.x"
+  },
   "dependencies": {
     "bower": "~1.3.3"
   }


### PR DESCRIPTION

Specify the version of node and the address of `bower register` to ensure the operation of example.

